### PR TITLE
Publish new version on release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,0 +1,23 @@
+name: Publish package on release
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Install all the dependencies
+      - run: yarn
+
+      # Publish the package to NPMs
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build:watch": "rollup -c -w",
     "lint": "eslint ./src/**",
     "lint:fix": "yarn run lint --fix",
-    "prepare": "yarn run build",
     "prerelease": "yarn run lint:fix && yarn run test:coverage && yarn run build",
     "release": "npm publish",
     "start": "yarn run build:watch start",


### PR DESCRIPTION
Fixes #18 

This PR makes it possible to automatically release the package to NPM whenever there is a new release.