### PR TITLE
Added: attributes as functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ const User = {
 export default User;
 ```
 
+#### Lazily evaluate the attributes
+
+Most of the time, defining the `attributes` as a object on the factory will be enough. However, the `attributes` can also be defined as a function. This is useful for when one wants to assign a dynamic value to any of the attributes.
+
+```js
+// ./factories/User.js
+import { v4 as uuid } from 'uuid'; // NOTE: The `uuid` library is not part of Factory Builder.
+
+const User = {
+  attributes: () => ({
+    id: uuid(),
+    firstName: 'Thom',
+    lastName: 'Taylor',
+    email: 'example@example.org',
+  })
+}
+
+export default User;
+```
+
 ### Consuming factories
 
 On it's own there is nothing special about factories. They're just plain javascript object that return a specifically styled object. To actually use the factory in your test you can make use of multiple methods that are provided by Factory Buider;
@@ -170,6 +190,25 @@ build(User, as: 'admin'); // => { firstName: 'Peter', isClient: false, isAdmin: 
 ```
 
 > **NOTE:** The variant must be a plain object and should be namespaced in your factory under `variants`. The key name will also be the way you pick this specific factory variant.
+
+The attributes of a specific variant can also be lazily evaluated. Just like the regular attributes of a Factory. To make use of the lazy evaluation, use a function that returns an object.
+
+```js
+import { v4 as uuid } from 'uuid'; // NOTE: The `uuid` library is not part of Factory Builder.
+
+const User = {
+  attributes: {
+    firstName: 'Peter',
+  },
+
+  variants: {
+    created: () => ({ id: uuid() })
+  }
+};
+
+import { build } from 'factory-builder';
+build(User, as: 'created'); // => { firstName: 'Peter', id: '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d' };
+```
 
 #### Quickly grab the attributes with `attributesFor`.
 

--- a/src/FactoryBuilder.js
+++ b/src/FactoryBuilder.js
@@ -1,12 +1,12 @@
+import attributesFor from './attributesFor';
 import build from './build';
 import buildList from './buildList';
-import { attributesFor } from './utils';
 
 const FactoryBuilder = {
+  attributesFor,
   build,
   buildList,
-  attributesFor,
 };
 
 export default FactoryBuilder;
-export { build, buildList, attributesFor };
+export { attributesFor, build, buildList };

--- a/src/__tests__/attributesFor.spec.js
+++ b/src/__tests__/attributesFor.spec.js
@@ -1,0 +1,73 @@
+import attributesFor from '../attributesFor';
+import { randomNumber } from '../utils';
+
+describe('attributesFor', () => {
+  describe('attributes as object', () => {
+    const Factory = () => ({
+      attributes: { some: 'key' },
+    });
+
+    it('assigns the attributes', () => {
+      const attributes = attributesFor(Factory);
+      expect(attributes.some).toEqual('key');
+    });
+
+    it('does not raise an exception when the factory is passed without instanciating it', () => {
+      expect(() => attributesFor(Factory)).not.toThrow();
+    });
+
+    it('does not raise an exception when the factory instance is passed', () => {
+      expect(() => attributesFor(new Factory())).not.toThrow();
+    });
+  });
+
+  describe('attributes as function', () => {
+    const id = randomNumber();
+
+    const Factory = () => ({
+      attributes: () => ({ id }),
+    });
+
+    it('evaluates the attributes function and assigns the attributes', () => {
+      const attributes = attributesFor(Factory);
+      expect(attributes.id).toEqual(id);
+    })
+
+    it('does not raise an exception when the factory is passed without instanciating it', () => {
+      expect(() => attributesFor(Factory)).not.toThrow();
+    });
+
+    it('does not raise an exception when the factory instance is passed', () => {
+      expect(() => attributesFor(new Factory())).not.toThrow();
+    });
+  });
+
+  describe('variants', () => {
+    const FactoryWithVariants = {
+      attributes: { color: 'red' },
+      variants: {
+        green: { color: 'green' },
+        purple: () => ({ color: 'purple' }),
+      },
+    };
+
+    it('always returns the default attributes without variant definition', () => {
+      const attributes = attributesFor(FactoryWithVariants);
+      expect(attributes.color).toEqual('red');
+    });
+
+    describe('with attributes as an object', () => {
+      it('returns the expected attributes', () => {
+        const attributes = attributesFor(FactoryWithVariants, 'green');
+        expect(attributes.color).toEqual('green');
+      })
+    });
+
+    describe('with attributes as an function', () => {
+      it('returns the expected attributes', () => {
+        const attributes = attributesFor(FactoryWithVariants, 'purple');
+        expect(attributes.color).toEqual('purple');
+      })
+    });
+  })
+});

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -1,20 +1,6 @@
-import { attributesFor, checkForUnknownAttributes, checkHookForFunction } from '../utils';
+import { checkForUnknownAttributes, checkHookForFunction } from '../utils';
 
 describe('utilities', () => {
-  describe('attributesFor', () => {
-    const Factory = () => ({
-      attributes: { some: 'key' },
-    });
-
-    it('does not raise an exception when the factory is passed without instanciating it', () => {
-      expect(() => attributesFor(Factory)).not.toThrow();
-    });
-
-    it('does not raise an exception when the factory instance is passed', () => {
-      expect(() => attributesFor(new Factory())).not.toThrow();
-    });
-  });
-
   describe('checkForUnknownAttributes', () => {
     const UnknownAttributesFactory = () => ({
       attributes: { some: 'key' },
@@ -32,7 +18,7 @@ describe('utilities', () => {
         `Please add these to the factory to be able to use them and clear this message.`;
 
       expect(() => {
-        checkForUnknownAttributes(factoryInstance, unknownAttributes);
+        checkForUnknownAttributes(factoryInstance.attributes, unknownAttributes);
       }).toThrow(expectedExceptionMessage);
     });
 
@@ -40,7 +26,7 @@ describe('utilities', () => {
       const whitelistedAttributes = { id: 1, createdAt: new Date(), updatedAt: new Date() };
 
       expect(() => {
-        checkForUnknownAttributes(factoryInstance, whitelistedAttributes);
+        checkForUnknownAttributes(factoryInstance.attributes, whitelistedAttributes);
       }).not.toThrow();
     });
   });

--- a/src/attributesFor.js
+++ b/src/attributesFor.js
@@ -1,0 +1,43 @@
+import { isFunction, isObject } from "./utils";
+
+/**
+ * Evaluates the attributes of a Factory.
+ * @param {Object|Function} attributes - The attributes of a factory
+ * @returns {Object} - The evaluated attributes
+ */
+const evaluateAttributes = (attributes) => isObject(attributes) ? attributes : attributes()
+
+/**
+ * Extracts the attributes of a Factory.
+ * @param {Object|Function} Factory - The factory or an instance of the factory
+ * @param {String} as - The variant for a factory
+ * @returns {Object} - The attributes of the factory
+ */
+const attributesFor = (Factory, as = undefined) => {
+  // It's possible to pass a instance that is not initiate yet to this method
+  // too. The internal methods will instanciate the, but when you use it directly
+  // it's also possible to use the uninstanciated variant directly.
+  const factoryInstance = isFunction(Factory) ? new Factory() : Factory;
+
+  // Now we will check whether the factory has implemented the `attributes` key
+  // or function. When that is not the case, we will ask the developer to implement this.
+  if (factoryInstance.attributes) {
+    // Get the base attributes for the factory. After this we can check for the variant.
+    const defaultAttributes = evaluateAttributes(factoryInstance.attributes)
+
+    // When the `as` param is undefined, we just return the base attributes. When
+    // the `as` param is defined, we want to merge the base attributes with the
+    // attributes of the variant.
+    if (!as) return defaultAttributes;
+
+    const variantAttributes = evaluateAttributes(factoryInstance.variants[as])
+    return { ...defaultAttributes, ...variantAttributes };
+  }
+
+  throw new Error(
+    'Every factory needs some sensible defaults. So please implement the ' +
+    'attributes method/key on the factory yourself.',
+  );
+};
+
+export default attributesFor;

--- a/src/build.js
+++ b/src/build.js
@@ -1,11 +1,17 @@
+import attributesFor from './attributesFor';
 import {
-  attributesFor,
   checkHookForReturnValue,
   checkForUnknownAttributes,
   isObject,
   checkHookForFunction,
 } from './utils';
 
+/**
+ * Builds a new instance for the Factory.
+ * @param {Object} factory - The Factory to build.
+ * @param {Object} parameters - A list of additional parameters for the build.
+ * @returns {Object} The build Factory instance.
+ */
 const build = (factory, parameters = {}) => {
   const { as, skipHooks, ...attributes } = parameters;
 
@@ -19,7 +25,7 @@ const build = (factory, parameters = {}) => {
   }
 
   // Check whether the given attributes are known to the instance
-  checkForUnknownAttributes(factory, attributes);
+  checkForUnknownAttributes(attributesFor(factory), attributes);
 
   // Let's start building this factory by merging the default attributes
   // of the factory with the given attributes that should override it

--- a/src/buildList.js
+++ b/src/buildList.js
@@ -1,11 +1,17 @@
 import build from './build';
 
+/**
+ * Builds multiple instances for the Factory.
+ * @param {Object} factory - The Factory to build multiple times.
+ * @param {Integer} count - The number of factories that should be returned.
+ * @param {Object} parameters - Optional parameters for the build.
+ * @returns {Array} A list of instances of the Factory.
+ */
 const buildList = (factory, count = 2, parameters = {}) => {
   if (Array.isArray(parameters)) {
     return new Array(count).fill().map((_val, idx) => build(factory, parameters.length > idx && parameters[idx] || {}));
   }
   return new Array(count).fill().map(() => build(factory, parameters));
 }
-  
 
 export default buildList;

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,43 +14,7 @@ export const isObject = item => typeof item === 'object' && !Array.isArray(item)
  * @returns {Boolean} - The result of the check for a function
  */
 
-const isFunction = item => !!(item && item.constructor && item.call && item.apply);
-
-/**
- * The `attributesFor` is a helper method that retrieves the attributes
- * from a factory instance. If none are found, it raises a helpful error
- * message.
- * @param {Object|Function} Factory - The factory or an instance of the factory
- * @param {String} - The variant for a factory
- * @returns {Object} - The attributes of the factory
- */
-
-export const attributesFor = (Factory, as = undefined) => {
-  // It's possible to pass a instance that is not initiate yet to this method
-  // too. The internal methods will instanciate the, but when you use it directly
-  // it's also possible to use the uninstanciated variant directly.
-  const factoryInstance = isFunction(Factory) ? new Factory() : Factory;
-
-  // Now we will check whether the factory has implemented the `attributes` key
-  // or function. When that is not the case, we will ask the developer to implement this.
-  if (factoryInstance.attributes) {
-    // Get the base attributes for the factory. After this we can check for the variant.
-    const baseAttributes = isObject(factoryInstance.attributes)
-      ? factoryInstance.attributes
-      : factoryInstance.attributes();
-
-    // When the `as` param is undefined, we just return the base attributes. When
-    // the `as` param is defined, we want to merge the base attributes with the
-    // attributes of the variant.
-    if (!as) return baseAttributes;
-    return { ...baseAttributes, ...factoryInstance.variants[as] };
-  }
-
-  throw new Error(
-    'Every factory needs some sensible defaults. So please implement the ' +
-      'attributes method/key on the factory yourself.',
-  );
-};
+export const isFunction = item => !!(item && item.constructor && item.call && item.apply);
 
 /**
  * The `checkHookForReturnValue` double checks whether a before/after hook
@@ -92,8 +56,8 @@ export const checkHookForFunction = (factory, hookName) => {
  * @param {Object} attributes - The attributes that will be added to the factory
  */
 
-export const checkForUnknownAttributes = (factory, attributes) => {
-  const factoryAttributes = Object.keys(attributesFor(factory));
+export const checkForUnknownAttributes = (factoryAttributes, attributes) => {
+  const factoryAttributeKeys = Object.keys(factoryAttributes);
   const whitelistedAttributes = ['id', 'createdAt', 'updatedAt'];
 
   // We check for none existing attributes, because we don't want to assign
@@ -101,7 +65,7 @@ export const checkForUnknownAttributes = (factory, attributes) => {
   // whitelisted attributes to make sure the developer can set these when
   // building or creating a new factory.
   const unknownAttributes = Object.keys(attributes).filter(
-    key => !factoryAttributes.includes(key) && !whitelistedAttributes.includes(key),
+    key => !factoryAttributeKeys.includes(key) && !whitelistedAttributes.includes(key),
   );
 
   // When there are unknown attributes, we raise an error that tells


### PR DESCRIPTION
It was a bit hidden, but it was already possible to use a function instead of an object for the attributes of a factory.

This PR adds documentation for how to use it and when to use it. It also extracts the `attributesFor` to its own file and extends the number of test cases for the `attributesFor` method.