### PR TITLE
Drop support for nodejs 12.x

### DIFF
--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It's heavily inspired by [FactoryBot](https://github.com/thoughtbot/factory_bot/
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
   - [❓ Questions](#-questions)
+  - [🛟 Supported versions](#-supported-nodejs-versions)
 
 ## Installation
 This module is distributed via npm which is bundled with node and should be installed as one of your project's devDependencies:
@@ -281,3 +282,7 @@ a 👍. This helps maintainers prioritize what to work on.
 
 For questions related to using the library, please file an issue on GitHub with
 the [Question](https://github.com/stefanvermaas/factory-builder/issues?utf8=✓&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3A"question"+) label.
+
+### 🛟 Supported NodeJS Versions
+
+NodeJS version `14.x` and up are supported. Older versions of NodeJS aren't explitly supported as they're not part of our CI setup. If you find anything, please let us know.


### PR DESCRIPTION
We're dropping explicit support for NodeJS `12.x` as it's not supported by Jest anymore. Use `12.x` and below at your own risk.